### PR TITLE
Removed the zray popup in mobile mode

### DIFF
--- a/templates/include/zray.phtml
+++ b/templates/include/zray.phtml
@@ -13,7 +13,7 @@
 
 <?php $this->inlineScript()->captureStart(); ?>
 (function($) {
-    if (getCookie('promoClosed') != 1) {
+    if (getCookie('promoClosed') != 1 && $(document).width() > $("#dialog_promo").width()) {
     	setTimeout(function() {
     		$( "#dialog_promo" ).slideDown( 2000 );
         }, 1000);


### PR DESCRIPTION
This PR fixes the issue #16 removing the Z-Ray popup if the window width is less than the zray div.