### PR TITLE
Fixes #33 - Old documentation links

### DIFF
--- a/templates/app/manual.phtml
+++ b/templates/app/manual.phtml
@@ -11,6 +11,14 @@
 <div class="container mtb" id="content">
     <div class="row">
         <div class="col-lg-8">
+            <!-- Warning message -->
+            <p class="alert alert-warning" role="alert">
+                <strong>Caution:</strong> The documentation you are viewing is
+                for an older version of Zend Framework.<br>
+                You can find the documentation of the current version at
+                <a href="https://docs.zendframework.com/">docs.zendframework.com</a>
+            </p>
+
             <p><?php echo $title ?></p>
             <h1 id="component-name"><?php echo $currentPageTitle ?></h1>
             <p>


### PR DESCRIPTION
![warning](https://cloud.githubusercontent.com/assets/103362/22888479/25b5e45a-f206-11e6-8ed5-aa6be8aadc03.png)
