### PR TITLE
Removes invalid CSS property value 'relative'

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -309,7 +309,6 @@ a:focus {
     margin-top: 0px;
 	padding-top:60px;
 	text-align:center;
-	background-attachment: relative;
 	background-position: center center;
 	min-height: 450px;
 	width: 100%;
@@ -347,7 +346,6 @@ a:focus {
     margin-top: 0px;
 	padding-top:60px;
 	text-align:center;
-	background-attachment: relative;
 	background-position: center center;
 	min-height: 450px;
 	width: 100%;
@@ -489,7 +487,6 @@ a:focus {
 	margin-top: -60px;
 	padding-top:0px;
 	text-align:center;
-	background-attachment: relative;
 	background-position: center center;
 	min-height: 400px;
 	width: 100%;


### PR DESCRIPTION
Standard value is scroll and the right choice for all background images.