### PR TITLE
Update contributor-guide.phtml

### DIFF
--- a/templates/app/contributor-guide.phtml
+++ b/templates/app/contributor-guide.phtml
@@ -114,7 +114,7 @@
     <li><a href="https://discourse.zendframework.com/t/welcome-to-the-zend-framework-discussion-forum/8">Welcome page, detailing policy and useful links.</a></li>
     <li><a href="https://discourse.zendframework.com/c/questions/components">Component/zend-mvc application questions</a></li>
     <li><a href="https://discourse.zendframework.com/c/questions/expressive">Expressive Questions</a></li>
-    <li><a href="https://discourse.zendframework.com/c/questions/apigility">Expressive Questions</a></li>
+    <li><a href="https://discourse.zendframework.com/c/questions/apigility">Apigility Questions</a></li>
     <li><a href="https://discourse.zendframework.com/c/contributors">Contributors section (questions about architecture, milestones, etc.)</a></li>
 </ul>
 


### PR DESCRIPTION
- Fix Apigility link title:

I also noticed that this two links redirect to a nonexistent pages: 

https://discourse.zendframework.com/c/questions/expressive
https://discourse.zendframework.com/c/questions/apigility

Maybe something need to be done on discourse.

Thanks!