### PR TITLE
Changed timeout in tests to 20s

### DIFF
--- a/test/AppTest/WebTest.php
+++ b/test/AppTest/WebTest.php
@@ -15,7 +15,7 @@ class WebTest extends TestCase
     {
         $this->client = new Client([
             'base_uri' => sprintf('http://%s:%s', WEB_SERVER_HOST, WEB_SERVER_PORT),
-            'timeout'  => 5,
+            'timeout'  => 20,
         ]);
     }
 


### PR DESCRIPTION
Fixes #82 

I've tried many things:
- changed dist to `precise` (less tests fails than on `trusty`)
- changed php version to 7.1
- changed port number for built-in server 
- changed timeout to 10, 15, 20 seconds

This is really weird, but all tests pass with 20 seconds timeout on `trusty`.
Better results I have got on `precise` - 15 seconds was enough.

Is travis slow??? 😨 



