### PR TITLE
Removed broken flex model

### DIFF
--- a/asset/sass/_zf-web.scss
+++ b/asset/sass/_zf-web.scss
@@ -33,8 +33,6 @@ body {
   line-height: 1.5;
   font-size: 16px;
   min-height: 100%;
-  display: flex;
-  flex-direction: column;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -106,10 +104,6 @@ a:focus {
 /*	################################################################
 	BOOTSTRAP MODIFICATIONS & TWEAKS
 ################################################################# */
-
-body > .container {
-  flex: 1;
-}
 
 .navbar {
   min-height: 70px;


### PR DESCRIPTION
It breaks footer on IE11 and printing on some browsers

Before that change on IE11 we had:
<img width="1280" alt="screen shot 2017-10-03 at 09 14 17" src="https://user-images.githubusercontent.com/7423207/31119350-9ebbd4bc-a828-11e7-8fe6-ff0a78525c74.png">

So the footer was overlapping the main container.

I've tested my changes on:
- IE11 Win10
- Edge Win10
- Firefox Win10
- Chrome macOS
- Safari macOS

All seems to be fine, it's possible to print blog article, maybe it's not perfect and the same on all browsers but at least it works for now. Definitely we can improve it, make the css styles clearer, but it's bigger job :)

Resolves #86 

/cc @ezimuel 