### PR TITLE
Generating list of repositories from github using github api

### DIFF
--- a/bin/build.php
+++ b/bin/build.php
@@ -115,20 +115,6 @@ printf('Post... ');
 $post = new Model\Post($parser);
 printf('done.' . PHP_EOL);
 
-printf('Building the config files:' . PHP_EOL);
-
-printf('Update ZF component list... ');
-$list = json_decode(
-    file_get_contents('https://docs.zendframework.com/zf-mkdoc-theme/scripts/zf-component-list.json'),
-    true
-);
-file_put_contents(
-    dirname(__DIR__) . '/config/autoload/zf-components.global.php',
-    '<' . '?php return [\'zf_components\' => ' . var_export($list, true) . '];',
-    LOCK_EX
-);
-printf('done.' . PHP_EOL);
-
 printf('Clearing config cache... ');
 if (getenv('APP_CACHE')) {
     $configCache = sprintf('%s/app_config.php', getenv('APP_CACHE'));

--- a/bin/repos.php
+++ b/bin/repos.php
@@ -1,0 +1,41 @@
+<?php
+chdir(dirname(__DIR__));
+require 'vendor/autoload.php';
+
+use Github\Client;
+use Zend\Config\Writer;
+
+if (! isset($argv[1])) {
+    fwrite(STDERR, printf("Usage: php %s <github token>\n", basename(__FILE__)));
+    exit(1);
+}
+
+$github = new Client();
+$github->authenticate($argv[1], null, $github::AUTH_URL_TOKEN);
+$org = $github->organization()->show('zendframework');
+$reposCount = $org['public_repos'];
+
+$repos = [];
+$page = 1;
+while (count($repos) < $reposCount) {
+    $results = $github->organization()->repositories('zendframework', 'public', $page);
+
+    foreach ($results as $repo) {
+        $repos[$repo['name']] = [
+            'description' => $repo['description'],
+            'docs' => (int) $github->repo()->contents()->exists('zendframework', $repo['name'], 'mkdocs.yml'),
+        ];
+    }
+
+    ++$page;
+}
+
+ksort($repos);
+
+$writer = new Writer\PhpArray();
+$writer->setUseBracketArraySyntax(true);
+
+$writer->toFile(
+    dirname(__DIR__) . '/config/autoload/zf-components.global.php',
+    ['zf_components' => $repos]
+);

--- a/bin/stats.php
+++ b/bin/stats.php
@@ -2,6 +2,8 @@
 chdir(dirname(__DIR__));
 require 'vendor/autoload.php';
 
+use Zend\Config\Writer;
+
 if (! isset($argv[1])) {
     fwrite(STDERR, printf("Usage: php %s <path/to/stat>\n", basename(__FILE__)));
     exit(1);
@@ -25,32 +27,31 @@ $stats = ['zf_stats' => []];
 
 printf("Generating the stats from packagist.org:\n");
 $tot = 0;
-foreach ($zfComponents['zf_components'] as $comp) {
-    $name = basename($comp['url']);
-    if ($name === 'tutorials') {
+foreach ($zfComponents['zf_components'] as $name => $comp) {
+    $apiUrl = sprintf('https://packagist.org/packages/zendframework/%s.json', $name);
+
+    $content = @file_get_contents($apiUrl);
+    if ($content === false) {
         continue;
     }
 
-    $apiUrl = sprintf('https://packagist.org/packages/zendframework/%s.json', $name);
-
-    printf('%s...', $name);
-
-    $json = json_decode(file_get_contents($apiUrl));
-    $date = time();
-    if (! empty($json)) {
+    printf('%s... ', $name);
+    $json = json_decode($content);
+    if (! empty($json->package->downloads)) {
         $stats['zf_stats'][$name] = [
             'daily'   => (int) $json->package->downloads->daily,
             'monthly' => (int) $json->package->downloads->monthly,
             'total'   => (int) $json->package->downloads->total,
         ];
+
+        $tot += $stats['zf_stats'][$name]['total'];
     }
 
     printf("done\n");
-    $tot += $stats['zf_stats'][$name]['total'];
 }
 
 $stats['zf_stats']['total'] = $tot;
-$stats['zf_stats']['date']  = $date;
+$stats['zf_stats']['date']  = time();
 
 // Store the stats and create the link under config/autoload
 file_put_contents($fileStats, '<' . '?php return '. var_export($stats, true) . ';', LOCK_EX);

--- a/composer.json
+++ b/composer.json
@@ -38,8 +38,11 @@
     "require-dev": {
         "filp/whoops": "^2.1.10",
         "guzzlehttp/guzzle": "^6.3",
+        "knplabs/github-api": "^2.6",
+        "php-http/guzzle6-adapter": "^1.1",
         "phpunit/phpunit": "^6.3",
         "zendframework/zend-coding-standard": "~1.0.0",
+        "zendframework/zend-config": "^3.1",
         "zfcampus/zf-development-mode": "^3.1"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "513dfb45fea3bd99ab81b086f4e0eff9",
+    "content-hash": "6a8101f8cabbae247011e91d05021998",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -2034,6 +2034,58 @@
     ],
     "packages-dev": [
         {
+            "name": "clue/stream-filter",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/php-stream-filter.git",
+                "reference": "d80fdee9b3a7e0d16fc330a22f41f3ad0eeb09d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/php-stream-filter/zipball/d80fdee9b3a7e0d16fc330a22f41f3ad0eeb09d0",
+                "reference": "d80fdee9b3a7e0d16fc330a22f41f3ad0eeb09d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.0 || ^4.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\StreamFilter\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@lueck.tv"
+                }
+            ],
+            "description": "A simple and modern approach to stream filtering in PHP",
+            "homepage": "https://github.com/clue/php-stream-filter",
+            "keywords": [
+                "bucket brigade",
+                "callback",
+                "filter",
+                "php_user_filter",
+                "stream",
+                "stream_filter_append",
+                "stream_filter_register"
+            ],
+            "time": "2017-08-18T09:54:01+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.0.5",
             "source": {
@@ -2330,6 +2382,74 @@
             "time": "2017-03-20T17:10:46+00:00"
         },
         {
+            "name": "knplabs/github-api",
+            "version": "2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/KnpLabs/php-github-api.git",
+                "reference": "cacf6f38bf9e6c5242e2b6dc26a67c4791bc7751"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/KnpLabs/php-github-api/zipball/cacf6f38bf9e6c5242e2b6dc26a67c4791bc7751",
+                "reference": "cacf6f38bf9e6c5242e2b6dc26a67c4791bc7751",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "php-http/cache-plugin": "^1.4",
+                "php-http/client-common": "^1.3",
+                "php-http/client-implementation": "^1.0",
+                "php-http/discovery": "^1.0",
+                "php-http/httplug": "^1.1",
+                "psr/cache": "^1.0",
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "cache/array-adapter": "^0.4",
+                "guzzlehttp/psr7": "^1.2",
+                "php-http/guzzle6-adapter": "^1.0",
+                "php-http/mock-client": "^1.0",
+                "phpunit/phpunit": "^4.0 || ^5.5",
+                "sllh/php-cs-fixer-styleci-bridge": "^1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Github\\": "lib/Github/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Thibault Duplessis",
+                    "email": "thibault.duplessis@gmail.com",
+                    "homepage": "http://ornicar.github.com"
+                },
+                {
+                    "name": "KnpLabs Team",
+                    "homepage": "http://knplabs.com"
+                }
+            ],
+            "description": "GitHub API v3 client",
+            "homepage": "https://github.com/KnpLabs/php-github-api",
+            "keywords": [
+                "api",
+                "gh",
+                "gist",
+                "github"
+            ],
+            "time": "2017-09-30T20:00:06+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.6.1",
             "source": {
@@ -2472,6 +2592,473 @@
             ],
             "description": "Library for handling version information and constraints",
             "time": "2017-03-05T17:38:23+00:00"
+        },
+        {
+            "name": "php-http/cache-plugin",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/cache-plugin.git",
+                "reference": "fe2730638f254934529006eb38aad8b5d427f475"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/cache-plugin/zipball/fe2730638f254934529006eb38aad8b5d427f475",
+                "reference": "fe2730638f254934529006eb38aad8b5d427f475",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.4 || ^7.0",
+                "php-http/client-common": "^1.1",
+                "php-http/message-factory": "^1.0",
+                "psr/cache": "^1.0",
+                "symfony/options-resolver": "^2.6 || ^3.0"
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "^1.0",
+                "phpspec/phpspec": "^2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Client\\Common\\Plugin\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "PSR-6 Cache plugin for HTTPlug",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "cache",
+                "http",
+                "httplug",
+                "plugin"
+            ],
+            "time": "2017-04-05T20:09:01+00:00"
+        },
+        {
+            "name": "php-http/client-common",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/client-common.git",
+                "reference": "154d36542eb96ee95daa504591eab78af2484baa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/client-common/zipball/154d36542eb96ee95daa504591eab78af2484baa",
+                "reference": "154d36542eb96ee95daa504591eab78af2484baa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "php-http/httplug": "^1.1",
+                "php-http/message": "^1.2",
+                "php-http/message-factory": "^1.0",
+                "symfony/options-resolver": "^2.6 || ^3.0"
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "^1.0",
+                "phpspec/phpspec": "^2.4"
+            },
+            "suggest": {
+                "php-http/cache-plugin": "PSR-6 Cache plugin",
+                "php-http/logger-plugin": "PSR-3 Logger plugin",
+                "php-http/stopwatch-plugin": "Symfony Stopwatch plugin"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Client\\Common\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Common HTTP Client implementations and tools for HTTPlug",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "client",
+                "common",
+                "http",
+                "httplug"
+            ],
+            "time": "2017-03-30T12:50:04+00:00"
+        },
+        {
+            "name": "php-http/discovery",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/discovery.git",
+                "reference": "7b50ab4d6c9fdaa1ed53ae310c955900af6e3372"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/7b50ab4d6c9fdaa1ed53ae310c955900af6e3372",
+                "reference": "7b50ab4d6c9fdaa1ed53ae310c955900af6e3372",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0"
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "^2.0.2",
+                "php-http/httplug": "^1.0",
+                "php-http/message-factory": "^1.0",
+                "phpspec/phpspec": "^2.4",
+                "puli/composer-plugin": "1.0.0-beta10"
+            },
+            "suggest": {
+                "php-http/message": "Allow to use Guzzle, Diactoros or Slim Framework factories",
+                "puli/composer-plugin": "Sets up Puli which is recommended for Discovery to work. Check http://docs.php-http.org/en/latest/discovery.html for more details."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Discovery\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Finds installed HTTPlug implementations and PSR-7 message factories",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "adapter",
+                "client",
+                "discovery",
+                "factory",
+                "http",
+                "message",
+                "psr7"
+            ],
+            "time": "2017-08-03T10:12:53+00:00"
+        },
+        {
+            "name": "php-http/guzzle6-adapter",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/guzzle6-adapter.git",
+                "reference": "a56941f9dc6110409cfcddc91546ee97039277ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/guzzle6-adapter/zipball/a56941f9dc6110409cfcddc91546ee97039277ab",
+                "reference": "a56941f9dc6110409cfcddc91546ee97039277ab",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.0",
+                "php": ">=5.5.0",
+                "php-http/httplug": "^1.0"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "1.0",
+                "php-http/client-implementation": "1.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "php-http/adapter-integration-tests": "^0.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Adapter\\Guzzle6\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                },
+                {
+                    "name": "David de Boer",
+                    "email": "david@ddeboer.nl"
+                }
+            ],
+            "description": "Guzzle 6 HTTP Adapter",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "Guzzle",
+                "http"
+            ],
+            "time": "2016-05-10T06:13:32+00:00"
+        },
+        {
+            "name": "php-http/httplug",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/httplug.git",
+                "reference": "1c6381726c18579c4ca2ef1ec1498fdae8bdf018"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/httplug/zipball/1c6381726c18579c4ca2ef1ec1498fdae8bdf018",
+                "reference": "1c6381726c18579c4ca2ef1ec1498fdae8bdf018",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "php-http/promise": "^1.0",
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "^1.0",
+                "phpspec/phpspec": "^2.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eric GELOEN",
+                    "email": "geloen.eric@gmail.com"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "HTTPlug, the HTTP client abstraction for PHP",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "client",
+                "http"
+            ],
+            "time": "2016-08-31T08:30:17+00:00"
+        },
+        {
+            "name": "php-http/message",
+            "version": "1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/message.git",
+                "reference": "2edd63bae5f52f79363c5f18904b05ce3a4b7253"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/message/zipball/2edd63bae5f52f79363c5f18904b05ce3a4b7253",
+                "reference": "2edd63bae5f52f79363c5f18904b05ce3a4b7253",
+                "shasum": ""
+            },
+            "require": {
+                "clue/stream-filter": "^1.3",
+                "php": ">=5.4",
+                "php-http/message-factory": "^1.0.2",
+                "psr/http-message": "^1.0"
+            },
+            "provide": {
+                "php-http/message-factory-implementation": "1.0"
+            },
+            "require-dev": {
+                "akeneo/phpspec-skip-example-extension": "^1.0",
+                "coduo/phpspec-data-provider-extension": "^1.0",
+                "ext-zlib": "*",
+                "guzzlehttp/psr7": "^1.0",
+                "henrikbjorn/phpspec-code-coverage": "^1.0",
+                "phpspec/phpspec": "^2.4",
+                "slim/slim": "^3.0",
+                "zendframework/zend-diactoros": "^1.0"
+            },
+            "suggest": {
+                "ext-zlib": "Used with compressor/decompressor streams",
+                "guzzlehttp/psr7": "Used with Guzzle PSR-7 Factories",
+                "slim/slim": "Used with Slim Framework PSR-7 implementation",
+                "zendframework/zend-diactoros": "Used with Diactoros Factories"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Message\\": "src/"
+                },
+                "files": [
+                    "src/filters.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "HTTP Message related tools",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7"
+            ],
+            "time": "2017-07-05T06:40:53+00:00"
+        },
+        {
+            "name": "php-http/message-factory",
+            "version": "v1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/message-factory.git",
+                "reference": "a478cb11f66a6ac48d8954216cfed9aa06a501a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/message-factory/zipball/a478cb11f66a6ac48d8954216cfed9aa06a501a1",
+                "reference": "a478cb11f66a6ac48d8954216cfed9aa06a501a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Factory interfaces for PSR-7 HTTP Message",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "stream",
+                "uri"
+            ],
+            "time": "2015-12-19T14:08:53+00:00"
+        },
+        {
+            "name": "php-http/promise",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/promise.git",
+                "reference": "dc494cdc9d7160b9a09bd5573272195242ce7980"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/promise/zipball/dc494cdc9d7160b9a09bd5573272195242ce7980",
+                "reference": "dc494cdc9d7160b9a09bd5573272195242ce7980",
+                "shasum": ""
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "^1.0",
+                "phpspec/phpspec": "^2.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                },
+                {
+                    "name": "Joel Wurtz",
+                    "email": "joel.wurtz@gmail.com"
+                }
+            ],
+            "description": "Promise used for asynchronous HTTP requests",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-01-26T13:27:02+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -3074,6 +3661,52 @@
                 "xunit"
             ],
             "time": "2017-08-03T14:08:16+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "time": "2016-08-06T20:24:11+00:00"
         },
         {
             "name": "psr/log",
@@ -3760,6 +4393,60 @@
             "time": "2017-05-22T02:43:20+00:00"
         },
         {
+            "name": "symfony/options-resolver",
+            "version": "v3.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "ff48982d295bcac1fd861f934f041ebc73ae40f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/ff48982d295bcac1fd861f934f041ebc73ae40f0",
+                "reference": "ff48982d295bcac1fd861f934f041ebc73ae40f0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony OptionsResolver Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "time": "2017-04-12T14:14:56+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.1.0",
             "source": {
@@ -3877,6 +4564,66 @@
                 "zf"
             ],
             "time": "2016-11-09T21:30:43+00:00"
+        },
+        {
+            "name": "zendframework/zend-config",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-config.git",
+                "reference": "a12e4a592bf66d9629b84960e268f3752e53abe4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-config/zipball/a12e4a592bf66d9629b84960e268f3752e53abe4",
+                "reference": "a12e4a592bf66d9629b84960e268f3752e53abe4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^5.6 || ^7.0",
+                "psr/container": "^1.0",
+                "zendframework/zend-stdlib": "^2.7.7 || ^3.1"
+            },
+            "conflict": {
+                "container-interop/container-interop": "<1.2.0"
+            },
+            "require-dev": {
+                "malukenho/docheader": "^0.1.5",
+                "phpunit/phpunit": "^5.7 || ^6.0",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-filter": "^2.7.1",
+                "zendframework/zend-i18n": "^2.7.3",
+                "zendframework/zend-servicemanager": "^2.7.8 || ^3.2.1"
+            },
+            "suggest": {
+                "zendframework/zend-filter": "^2.7.1; install if you want to use the Filter processor",
+                "zendframework/zend-i18n": "^2.7.3; install if you want to use the Translator processor",
+                "zendframework/zend-servicemanager": "^2.7.8 || ^3.2.1; if you need an extensible plugin manager for use with the Config Factory"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev",
+                    "dev-develop": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Config\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides a nested object property based user interface for accessing this configuration data within application code",
+            "homepage": "https://github.com/zendframework/zend-config",
+            "keywords": [
+                "config",
+                "zf2"
+            ],
+            "time": "2017-02-22T14:31:10+00:00"
         },
         {
             "name": "zfcampus/zf-development-mode",

--- a/config/autoload/zf-components.global.php
+++ b/config/autoload/zf-components.global.php
@@ -1,416 +1,601 @@
-<?php return ['zf_components' => array (
-  0 => 
-  array (
-    'name' => 'Tutorials',
-    'url' => 'https://docs.zendframework.com/tutorials',
-    'description' => 'Learn how to create zend-mvc applications, get in-depth guides into components, and discover how to migrate your applications to version 3!',
-  ),
-  1 => 
-  array (
-    'name' => 'Authentication',
-    'url' => 'https://docs.zendframework.com/zend-authentication',
-    'description' => 'Authenticate users via a variety of adapters, and provide the authenticated identity to your application.',
-  ),
-  2 => 
-  array (
-    'name' => 'Barcode',
-    'url' => 'https://docs.zendframework.com/zend-barcode',
-    'description' => 'Programmatically create and render barcodes as images or in PDFs.',
-  ),
-  3 => 
-  array (
-    'name' => 'Cache',
-    'url' => 'https://docs.zendframework.com/zend-cache/',
-    'description' => 'Caching implementation with a variety of storage options, as well as codified caching strategies for callbacks, classes, and output.',
-  ),
-  4 => 
-  array (
-    'name' => 'Captcha',
-    'url' => 'https://docs.zendframework.com/zend-captcha/',
-    'description' => 'Generate and validate CAPTCHAs using Figlets, images, ReCaptcha, and more.',
-  ),
-  5 => 
-  array (
-    'name' => 'Code',
-    'url' => 'https://docs.zendframework.com/zend-code/',
-    'description' => 'Extensions to the PHP Reflection API, static code scanning, and code generation.',
-  ),
-  6 => 
-  array (
-    'name' => 'Component Installer',
-    'url' => 'https://docs.zendframework.com/zend-component-installer/',
-    'description' => 'Composer plugin for injecting modules and configuration providers into application configuration.',
-  ),
-  7 => 
-  array (
-    'name' => 'Config',
-    'url' => 'https://docs.zendframework.com/zend-config/',
-    'description' => 'Read and write configuration files.',
-  ),
-  8 => 
-  array (
-    'name' => 'ConfigAggregator',
-    'url' => 'https://docs.zendframework.com/zend-config-aggregator/',
-    'description' => 'Lightweight library for collecting and merging configuration from different sources.',
-  ),
-  9 => 
-  array (
-    'name' => 'Console',
-    'url' => 'https://docs.zendframework.com/zend-console/',
-    'description' => 'Build console applications using getopt syntax or routing, complete with prompts',
-  ),
-  10 => 
-  array (
-    'name' => 'Crypt',
-    'url' => 'https://docs.zendframework.com/zend-crypt/',
-    'description' => 'Strong cryptography tools and password hashing.',
-  ),
-  11 => 
-  array (
-    'name' => 'DB',
-    'url' => 'https://docs.zendframework.com/zend-db/',
-    'description' => 'Database abstraction layer, SQL abstraction, result set abstraction, and RowDataGateway and TableDataGateway implementations.',
-  ),
-  12 => 
-  array (
-    'name' => 'Debug',
-    'url' => 'https://docs.zendframework.com/zend-debug/',
-    'description' => 'Safely dump debug information to HTML.',
-  ),
-  13 => 
-  array (
-    'name' => 'DI',
-    'url' => 'https://docs.zendframework.com/zend-di/',
-    'description' => 'Automated dependency injection and instance manager.',
-  ),
-  14 => 
-  array (
-    'name' => 'Diactoros',
-    'url' => 'https://docs.zendframework.com/zend-diactoros/',
-    'description' => 'PSR-7 HTTP message implementations.',
-  ),
-  15 => 
-  array (
-    'name' => 'DOM',
-    'url' => 'https://docs.zendframework.com/zend-dom/',
-    'description' => 'Query HTML and XML documents using XPath or CSS selectors.',
-  ),
-  16 => 
-  array (
-    'name' => 'Escaper',
-    'url' => 'https://docs.zendframework.com/zend-escaper/',
-    'description' => 'Securely and safely escape HTML, HTML attributes, JavaScript, CSS, and URLs.',
-  ),
-  17 => 
-  array (
-    'name' => 'EventManager',
-    'url' => 'https://docs.zendframework.com/zend-eventmanager/',
-    'description' => 'Implement events, signal slots, aspects, and observers!',
-  ),
-  18 => 
-  array (
-    'name' => 'Expressive',
-    'url' => 'https://docs.zendframework.com/zend-expressive/',
-    'description' => 'PSR-7 middleware in minutes.',
-  ),
-  19 => 
-  array (
-    'name' => 'Feed',
-    'url' => 'https://docs.zendframework.com/zend-feed/',
-    'description' => 'Consume and generate Atom and RSS feeds, and interact with Pubsubhubbub.',
-  ),
-  20 => 
-  array (
-    'name' => 'File',
-    'url' => 'https://docs.zendframework.com/zend-file/',
-    'description' => 'Locate PHP classfiles.',
-  ),
-  21 => 
-  array (
-    'name' => 'Filter',
-    'url' => 'https://docs.zendframework.com/zend-filter/',
-    'description' => 'Programmatically filter and normalize data and files.',
-  ),
-  22 => 
-  array (
-    'name' => 'Form',
-    'url' => 'https://docs.zendframework.com/zend-form/',
-    'description' => 'Validate and display simple and complex forms, casting forms to business objects and vice versa.',
-  ),
-  23 => 
-  array (
-    'name' => 'HAL for PSR-7',
-    'url' => 'https://docs.zendframework.com/zend-expressive-hal/',
-    'description' => 'Hypertext Application Language (HAL) for PSR-7.',
-  ),
-  24 => 
-  array (
-    'name' => 'HTTP',
-    'url' => 'https://docs.zendframework.com/zend-http/',
-    'description' => 'HTTP message and header abstractions, and HTTP client implementation.  (Not a PSR-7 implementation.)',
-  ),
-  25 => 
-  array (
-    'name' => 'Hydrator',
-    'url' => 'https://docs.zendframework.com/zend-hydrator/',
-    'description' => 'Serialize objects to arrays, and vice versa.',
-  ),
-  26 => 
-  array (
-    'name' => 'InputFilter',
-    'url' => 'https://docs.zendframework.com/zend-inputfilter/',
-    'description' => 'Normalize and validate input sets from the web, APIs, the CLI, and more, including files.',
-  ),
-  27 => 
-  array (
-    'name' => 'Internationalization',
-    'url' => 'https://docs.zendframework.com/zend-i18n/',
-    'description' => 'Provide translations for your application, and filter and validate internationalized values.',
-  ),
-  28 => 
-  array (
-    'name' => 'JSON',
-    'url' => 'https://docs.zendframework.com/zend-json/',
-    'description' => 'De/Serialize JSON in PHP, including JavaScript expressions.',
-  ),
-  29 => 
-  array (
-    'name' => 'JSON-RPC Server',
-    'url' => 'https://docs.zendframework.com/zend-json-server/',
-    'description' => 'JSON-RPC implementation for PHP.',
-  ),
-  30 => 
-  array (
-    'name' => 'LDAP',
-    'url' => 'https://docs.zendframework.com/zend-ldap/',
-    'description' => 'Perform LDAP operations, including binding, searching and modifying entries in an LDAP directory.',
-  ),
-  31 => 
-  array (
-    'name' => 'Loader',
-    'url' => 'https://docs.zendframework.com/zend-loader/',
-    'description' => 'Autoloading and plugin loading strategies.',
-  ),
-  32 => 
-  array (
-    'name' => 'Log',
-    'url' => 'https://docs.zendframework.com/zend-log/',
-    'description' => 'Robust, composite logger with filtering, formatting, and PSR-3 support.',
-  ),
-  33 => 
-  array (
-    'name' => 'Mail',
-    'url' => 'https://docs.zendframework.com/zend-mail/',
-    'description' => 'Parse, create, store, and send email messages, using a variety of storage and transport protocols.',
-  ),
-  34 => 
-  array (
-    'name' => 'Math',
-    'url' => 'https://docs.zendframework.com/zend-math/',
-    'description' => 'Create cryptographically secure pseudo-random numbers, and manage big integers.',
-  ),
-  35 => 
-  array (
-    'name' => 'Memory',
-    'url' => 'https://docs.zendframework.com/zend-memory/',
-    'description' => 'Manage data in an environment with limited memory.',
-  ),
-  36 => 
-  array (
-    'name' => 'MIME',
-    'url' => 'https://docs.zendframework.com/zend-mime/',
-    'description' => 'Create and parse MIME messages and parts.',
-  ),
-  37 => 
-  array (
-    'name' => 'Module Manager',
-    'url' => 'https://docs.zendframework.com/zend-modulemanager/',
-    'description' => 'Modular application system for zend-mvc applications.',
-  ),
-  38 => 
-  array (
-    'name' => 'MVC',
-    'url' => 'https://docs.zendframework.com/zend-mvc/',
-    'description' => 'Zend Framework\'s event-driven MVC layer, including MVC Applications, Controllers, and Plugins.',
-  ),
-  39 => 
-  array (
-    'name' => 'MVC-Console integration',
-    'url' => 'https://docs.zendframework.com/zend-mvc-console/',
-    'description' => 'Integration between zend-mvc and zend-console.',
-  ),
-  40 => 
-  array (
-    'name' => 'MVC-i18n integration',
-    'url' => 'https://docs.zendframework.com/zend-mvc-i18n/',
-    'description' => 'Integration between zend-mvc and zend-i18n.',
-  ),
-  41 => 
-  array (
-    'name' => 'fileprg() plugin',
-    'url' => 'https://docs.zendframework.com/zend-mvc-plugin-fileprg/',
-    'description' => 'Post/Redirect/Get plugin with file upload handling for zend-mvc controllers.',
-  ),
-  42 => 
-  array (
-    'name' => 'flashmessenger() plugin',
-    'url' => 'https://docs.zendframework.com/zend-mvc-plugin-flashmessenger/',
-    'description' => 'Plugin for creating and exposing flash messages via zend-mvc controllers.',
-  ),
-  43 => 
-  array (
-    'name' => 'identity() plugin',
-    'url' => 'https://docs.zendframework.com/zend-mvc-plugin-identity/',
-    'description' => 'Plugin for retrieving the current authenticated identity within zend-mvc controllers.',
-  ),
-  44 => 
-  array (
-    'name' => 'prg() plugin',
-    'url' => 'https://docs.zendframework.com/zend-mvc-plugin-prg/',
-    'description' => 'Post/Redirect/Get plugin for zend-mvc controllers.',
-  ),
-  45 => 
-  array (
-    'name' => 'Navigation',
-    'url' => 'https://docs.zendframework.com/zend-navigation/',
-    'description' => 'Manage trees of pointers to web pages in order to build navigation systems.',
-  ),
-  46 => 
-  array (
-    'name' => 'Paginator',
-    'url' => 'https://docs.zendframework.com/zend-paginator/',
-    'description' => 'Paginate collections of data from arbitrary sources.',
-  ),
-  47 => 
-  array (
-    'name' => 'ACL',
-    'url' => 'https://docs.zendframework.com/zend-permissions-acl/',
-    'description' => 'Create, manage, and query access control lists.',
-  ),
-  48 => 
-  array (
-    'name' => 'RBAC',
-    'url' => 'https://docs.zendframework.com/zend-permissions-rbac/',
-    'description' => 'Provide and query Role-Based Access Controls for your application.',
-  ),
-  49 => 
-  array (
-    'name' => 'Problem Details',
-    'url' => 'https://docs.zendframework.com/zend-problem-details/',
-    'description' => 'PSR-7 Problem Details for HTTP API responses and middleware.',
-  ),
-  50 => 
-  array (
-    'name' => 'ProgressBar',
-    'url' => 'https://docs.zendframework.com/zend-progressbar/',
-    'description' => 'Create and update progress bars in different environments.',
-  ),
-  51 => 
-  array (
-    'name' => 'PSR-7 Bridge',
-    'url' => 'https://docs.zendframework.com/zend-psr7bridge/',
-    'description' => 'PSR-7 &lt;-&gt; zend-http message conversions.',
-  ),
-  52 => 
-  array (
-    'name' => 'Router',
-    'url' => 'https://docs.zendframework.com/zend-router/',
-    'description' => 'Flexible routing system for HTTP and console applications.',
-  ),
-  53 => 
-  array (
-    'name' => 'Serializer',
-    'url' => 'https://docs.zendframework.com/zend-serializer/',
-    'description' => 'Serialize and deserialize PHP structures to a variety of representations.',
-  ),
-  54 => 
-  array (
-    'name' => 'Server',
-    'url' => 'https://docs.zendframework.com/zend-server/',
-    'description' => 'Create Reflection-based RPC servers.',
-  ),
-  55 => 
-  array (
-    'name' => 'ServiceManager',
-    'url' => 'https://docs.zendframework.com/zend-servicemanager/',
-    'description' => 'Factory-Driven Dependency Injection Container',
-  ),
-  56 => 
-  array (
-    'name' => 'ServiceManager-Di integration',
-    'url' => 'https://docs.zendframework.com/zend-servicemanager-di/',
-    'description' => 'zend-di integration for zend-servicemanager',
-  ),
-  57 => 
-  array (
-    'name' => 'Session',
-    'url' => 'https://docs.zendframework.com/zend-session/',
-    'description' => 'Object-oriented interface to PHP sessions and storage.',
-  ),
-  58 => 
-  array (
-    'name' => 'SOAP',
-    'url' => 'https://docs.zendframework.com/zend-soap/',
-    'description' => 'Create, serve, and access SOAP applications, and parse and generate WSDL.',
-  ),
-  59 => 
-  array (
-    'name' => 'Stdlib',
-    'url' => 'https://docs.zendframework.com/zend-stdlib/',
-    'description' => 'SPL extensions, array utilities, error handlers, and more.',
-  ),
-  60 => 
-  array (
-    'name' => 'Stratigility',
-    'url' => 'https://docs.zendframework.com/zend-stratigility/',
-    'description' => 'PSR-7 middleware foundation for building and dispatching middleware pipelines.',
-  ),
-  61 => 
-  array (
-    'name' => 'Tag',
-    'url' => 'https://docs.zendframework.com/zend-tag/',
-    'description' => 'Manipulate and weight taggable items, and create tag clouds.',
-  ),
-  62 => 
-  array (
-    'name' => 'Test',
-    'url' => 'https://docs.zendframework.com/zend-test/',
-    'description' => 'Tools to facilitate unit testing of zend-mvc applications.',
-  ),
-  63 => 
-  array (
-    'name' => 'Text',
-    'url' => 'https://docs.zendframework.com/zend-text/',
-    'description' => 'Create FIGlets and text-based tables.',
-  ),
-  64 => 
-  array (
-    'name' => 'URI',
-    'url' => 'https://docs.zendframework.com/zend-uri/',
-    'description' => 'Object oriented interface to URIs, with facilities for validation.',
-  ),
-  65 => 
-  array (
-    'name' => 'Validator',
-    'url' => 'https://docs.zendframework.com/zend-validator/',
-    'description' => 'Validation classes for a wide range of domains, and the ability to chain validators to create complex validation criteria.',
-  ),
-  66 => 
-  array (
-    'name' => 'View',
-    'url' => 'https://docs.zendframework.com/zend-view/',
-    'description' => 'Flexible view layer supporting and providing multiple view layers, helpers, and more.',
-  ),
-  67 => 
-  array (
-    'name' => 'XML-RPC',
-    'url' => 'https://docs.zendframework.com/zend-xmlrpc/',
-    'description' => 'Fully-featured XML-RPC server and client implementations.',
-  ),
-  68 => 
-  array (
-    'name' => 'XML2JSON',
-    'url' => 'https://docs.zendframework.com/zend-xml2json/',
-    'description' => 'Convert XML documents to JSON.',
-  ),
-)];
+<?php
+return [
+    'zf_components' => [
+        'Namespacer' => [
+            'description' => 'PHP Class converter to namepaces.',
+            'docs' => 0,
+        ],
+        'ZF2Package' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZFTool' => [
+            'description' => 'Utility module for maintaining modular Zend Framework 2 applications.',
+            'docs' => 0,
+        ],
+        'ZendAmf' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendCloud' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendDeveloperTools' => [
+            'description' => 'Module for developer and debug tools for working with the ZF2 MVC layer.',
+            'docs' => 0,
+        ],
+        'ZendDiagnostics' => [
+            'description' => 'Universal set of diagnostic tests for PHP applications.',
+            'docs' => 0,
+        ],
+        'ZendGData' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendMarkup' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendOAuth' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendOpenId' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendPdf' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendQueue' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendRest' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendSearch' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendService_AgileZen' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendService_Akismet' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendService_Amazon' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendService_Api' => [
+            'description' => 'A micro HTTP framework to consume generic API calls',
+            'docs' => 0,
+        ],
+        'ZendService_Apple_Apns' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendService_Audioscrobbler' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendService_Delicious' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendService_DeveloperGarden' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendService_Flickr' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendService_GoGrid' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendService_Google_C2dm' => [
+            'description' => 'Zend Framework 2 Library for Sending Google C2DM Messages',
+            'docs' => 0,
+        ],
+        'ZendService_Google_Gcm' => [
+            'description' => 'Implementation for ZF2 of a GCM 3rd party server (http://developer.android.com/guide/google/gcm/)',
+            'docs' => 0,
+        ],
+        'ZendService_LiveDocx' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendService_Nirvanix' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendService_OpenStack' => [
+            'description' => 'OOP wrapper for the OpenStack API',
+            'docs' => 0,
+        ],
+        'ZendService_Rackspace' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendService_ReCaptcha' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendService_SlideShare' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendService_StrikeIron' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendService_Technorati' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendService_Twitter' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendService_WindowsAzure' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendSkeletonApplication' => [
+            'description' => 'Skeleton application for zend-mvc projects',
+            'docs' => 0,
+        ],
+        'ZendSkeletonModule' => [
+            'description' => 'Sample skeleton module for use with the ZF2 MVC layer',
+            'docs' => 0,
+        ],
+        'ZendTimeSync' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'ZendXml' => [
+            'description' => 'Utility library for XML usage and best practices in PHP',
+            'docs' => 0,
+        ],
+        'Zend_Db-Examples' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'component-split' => [
+            'description' => 'Script/utilities for splitting ZF2 components into their own repositories.',
+            'docs' => 0,
+        ],
+        'documentation' => [
+            'description' => 'Next-gen documentation repository for Zend Framework components.',
+            'docs' => 0,
+        ],
+        'maintainers' => [
+            'description' => 'Contributors and maintainers information for Zend Framework.',
+            'docs' => 0,
+        ],
+        'modules.zendframework.com' => [
+            'description' => 'Home for ZF2 module distribution',
+            'docs' => 0,
+        ],
+        'modules.zendframework.com-Behat' => [
+            'description' => 'Behat test for modules.zendframework.com',
+            'docs' => 0,
+        ],
+        'subsplit' => [
+            'description' => 'Tools for managing the ZF2 component subsplits',
+            'docs' => 0,
+        ],
+        'subsplit-ng' => [
+            'description' => 'New tool for automating component subsplits',
+            'docs' => 0,
+        ],
+        'tutorials' => [
+            'description' => 'Tutorials for Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-authentication' => [
+            'description' => 'Authentication component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-barcode' => [
+            'description' => 'Barcode component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-cache' => [
+            'description' => null,
+            'docs' => 1,
+        ],
+        'zend-captcha' => [
+            'description' => 'Captcha component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-code' => [
+            'description' => null,
+            'docs' => 1,
+        ],
+        'zend-coding-standard' => [
+            'description' => 'Zend Framework Coding Standard',
+            'docs' => 0,
+        ],
+        'zend-component-installer' => [
+            'description' => 'Composer post-package-(un)install scripts for modules and components.',
+            'docs' => 1,
+        ],
+        'zend-config' => [
+            'description' => 'Config component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-config-aggregator' => [
+            'description' => 'Aggregate and merge configuration from a variety of sources.',
+            'docs' => 1,
+        ],
+        'zend-console' => [
+            'description' => 'Console component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-crypt' => [
+            'description' => 'Cryptographic component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-db' => [
+            'description' => 'Db component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-debug' => [
+            'description' => 'Debug component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-di' => [
+            'description' => 'Di component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-diactoros' => [
+            'description' => 'PSR-7 HTTP Message implementation',
+            'docs' => 1,
+        ],
+        'zend-dom' => [
+            'description' => 'Dom component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-escaper' => [
+            'description' => 'Escaper component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-eventmanager' => [
+            'description' => 'Implement event systems, signal slots, intercepting filters, and observers.',
+            'docs' => 1,
+        ],
+        'zend-expressive' => [
+            'description' => 'PSR-7 middleware in minutes!',
+            'docs' => 1,
+        ],
+        'zend-expressive-aurarouter' => [
+            'description' => 'Aura.Router integration for Expressive',
+            'docs' => 0,
+        ],
+        'zend-expressive-authorization' => [
+            'description' => 'Authorization middleware for PSR-7 applications and Expressive',
+            'docs' => 1,
+        ],
+        'zend-expressive-authorization-acl' => [
+            'description' => 'zend-acl adapter for zend-expressive-authorization-acl',
+            'docs' => 1,
+        ],
+        'zend-expressive-authorization-rbac' => [
+            'description' => 'zend-rbac adapter for zend-expressive-authorization',
+            'docs' => 1,
+        ],
+        'zend-expressive-fastroute' => [
+            'description' => 'FastRoute integration for Expressive',
+            'docs' => 0,
+        ],
+        'zend-expressive-hal' => [
+            'description' => 'Hypertext Application Language implementation for PHP and PSR-7',
+            'docs' => 1,
+        ],
+        'zend-expressive-helpers' => [
+            'description' => 'Helper classes for Expressive',
+            'docs' => 0,
+        ],
+        'zend-expressive-platesrenderer' => [
+            'description' => 'Plates integration for Expressive',
+            'docs' => 0,
+        ],
+        'zend-expressive-router' => [
+            'description' => 'Router subcomponent for Expressive',
+            'docs' => 0,
+        ],
+        'zend-expressive-skeleton' => [
+            'description' => 'Begin developing PSR-7 middleware applications in seconds!',
+            'docs' => 0,
+        ],
+        'zend-expressive-template' => [
+            'description' => 'Template subcomponent for Expressive',
+            'docs' => 0,
+        ],
+        'zend-expressive-tooling' => [
+            'description' => 'Migration and development tooling for Expressive',
+            'docs' => 0,
+        ],
+        'zend-expressive-twigrenderer' => [
+            'description' => 'Twig integration for Expressive',
+            'docs' => 0,
+        ],
+        'zend-expressive-zendrouter' => [
+            'description' => 'zend-mvc Router integration for Expressive',
+            'docs' => 0,
+        ],
+        'zend-expressive-zendviewrenderer' => [
+            'description' => 'zend-view PhpRenderer integration for Expressive',
+            'docs' => 0,
+        ],
+        'zend-feed' => [
+            'description' => 'Feed component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-file' => [
+            'description' => 'File component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-filter' => [
+            'description' => 'Filter component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-form' => [
+            'description' => 'Form component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-http' => [
+            'description' => 'Http component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-hydrator' => [
+            'description' => 'Object hydrators and array extraction',
+            'docs' => 1,
+        ],
+        'zend-i18n' => [
+            'description' => 'I18n component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-i18n-resources' => [
+            'description' => 'Translation resources for zend-i18n',
+            'docs' => 1,
+        ],
+        'zend-inputfilter' => [
+            'description' => 'InputFilter component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-json' => [
+            'description' => 'Json component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-json-server' => [
+            'description' => 'JSON-RPC implementation for PHP',
+            'docs' => 1,
+        ],
+        'zend-ldap' => [
+            'description' => 'Ldap component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-loader' => [
+            'description' => 'Loader component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-log' => [
+            'description' => 'Log component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-mail' => [
+            'description' => 'Mail component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-math' => [
+            'description' => 'Math component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-memory' => [
+            'description' => 'Memory component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-mime' => [
+            'description' => 'Mime component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-modulemanager' => [
+            'description' => 'ModuleManager component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-mvc' => [
+            'description' => 'Mvc component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-mvc-console' => [
+            'description' => 'Integration between zend-console, zend-router, zend-view, and zend-mvc',
+            'docs' => 1,
+        ],
+        'zend-mvc-form' => [
+            'description' => 'Metapackage with all requirements for using zend-form with zend-mvc',
+            'docs' => 0,
+        ],
+        'zend-mvc-i18n' => [
+            'description' => null,
+            'docs' => 1,
+        ],
+        'zend-mvc-plugin-fileprg' => [
+            'description' => null,
+            'docs' => 1,
+        ],
+        'zend-mvc-plugin-flashmessenger' => [
+            'description' => null,
+            'docs' => 1,
+        ],
+        'zend-mvc-plugin-identity' => [
+            'description' => null,
+            'docs' => 1,
+        ],
+        'zend-mvc-plugin-prg' => [
+            'description' => 'Post/Redirect/Get controller plugin for zend-mvc',
+            'docs' => 1,
+        ],
+        'zend-mvc-plugins' => [
+            'description' => 'Official, single-repository zend-mvc plugins in a single composer metapackage.',
+            'docs' => 0,
+        ],
+        'zend-navigation' => [
+            'description' => 'Navigation component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-paginator' => [
+            'description' => 'Paginator component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-permissions-acl' => [
+            'description' => null,
+            'docs' => 1,
+        ],
+        'zend-permissions-rbac' => [
+            'description' => 'Create and query role-based access controls.',
+            'docs' => 1,
+        ],
+        'zend-problem-details' => [
+            'description' => 'Provides Problem Details for HTTP APIs (RFC 7807) support for PSR-7 applications.',
+            'docs' => 1,
+        ],
+        'zend-progressbar' => [
+            'description' => 'ProgressBar component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-psr7bridge' => [
+            'description' => 'PSR-7 <-> zend-http message conversions',
+            'docs' => 1,
+        ],
+        'zend-router' => [
+            'description' => 'Standalone routing implementation for HTTP and console requests',
+            'docs' => 1,
+        ],
+        'zend-serializer' => [
+            'description' => 'Serializer component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-server' => [
+            'description' => 'Server component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-servicemanager' => [
+            'description' => 'ServiceManager component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-servicemanager-di' => [
+            'description' => 'zend-di <-> zend-servicemanager integration',
+            'docs' => 1,
+        ],
+        'zend-session' => [
+            'description' => 'Session component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-skeleton-installer' => [
+            'description' => 'Composer plugin for installing optional packages in skeleton projects.',
+            'docs' => 1,
+        ],
+        'zend-soap' => [
+            'description' => 'Soap component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-stdlib' => [
+            'description' => 'Stdlib component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-stratigility' => [
+            'description' => 'Middleware for PHP built on top of PSR-7',
+            'docs' => 1,
+        ],
+        'zend-tag' => [
+            'description' => 'Tag component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-test' => [
+            'description' => 'Test component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-text' => [
+            'description' => 'Text component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-uri' => [
+            'description' => 'Uri component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-validator' => [
+            'description' => 'Validator component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-version' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'zend-view' => [
+            'description' => 'View component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zend-xml2json' => [
+            'description' => null,
+            'docs' => 1,
+        ],
+        'zend-xmlrpc' => [
+            'description' => 'XmlRpc component from Zend Framework',
+            'docs' => 1,
+        ],
+        'zendframework' => [
+            'description' => 'Official Zend Framework repository',
+            'docs' => 0,
+        ],
+        'zendframework.github.io' => [
+            'description' => 'Placeholder site for online ZF documentation.',
+            'docs' => 0,
+        ],
+        'zf-composer-repository' => [
+            'description' => 'Composer repository generation for packages.zendframework.com',
+            'docs' => 0,
+        ],
+        'zf-mkdoc-theme' => [
+            'description' => 'MkDocs theme and gh-pages automation scripts for ZF documentation',
+            'docs' => 0,
+        ],
+        'zf-web' => [
+            'description' => 'Sources for the Zend Framework website',
+            'docs' => 0,
+        ],
+        'zf1' => [
+            'description' => 'EOL on 2016-09-28. Contains conversion of ZF1 subversion repo to git, from version 15234 forward, and only containing master and release-1.12 branches and 1.12 tags.',
+            'docs' => 0,
+        ],
+        'zf1-extras' => [
+            'description' => '"Extras" repository from Zend Framework 1.x, containing jQuery integration, console forking, and Firebird DB adapter',
+            'docs' => 0,
+        ],
+        'zf2-documentation' => [
+            'description' => 'Zend Framework 2 documentation sources',
+            'docs' => 0,
+        ],
+        'zf2-tutorial' => [
+            'description' => null,
+            'docs' => 0,
+        ],
+        'zf3-web' => [
+            'description' => 'Website of Zend Framework 3',
+            'docs' => 0,
+        ],
+        'zfbot' => [
+            'description' => 'Chatbot for the Zend Framework Slack',
+            'docs' => 0,
+        ],
+    ],
+];

--- a/templates/app/issue-overview.phtml
+++ b/templates/app/issue-overview.phtml
@@ -17,8 +17,8 @@
     </div>
 
     <div class="list-group hidden">
-        <?php foreach ($repository as $component) : ?>
-            <a class="list-group-item" href="https://github.com/zendframework/<?= basename($component['url']) ?>/issues"><?= basename($component['url']) ?></a>
+        <?php foreach ($repository as $name => $component) : ?>
+            <a class="list-group-item" href="https://github.com/zendframework/<?= $name ?>/issues"><?= $name ?></a>
         <?php endforeach ?>
     </div>
 </div>

--- a/templates/app/learn.phtml
+++ b/templates/app/learn.phtml
@@ -33,12 +33,16 @@ reset($components);
     </div>
 </div>
 
-<?php while ($comp = next($components)) : ?>
-    <div class="row">
+<?php foreach ($components as $name => $comp) : ?>
+    <?php
+    if (! $comp['docs']) {
+        continue;
+    }
+    ?>
         <div class="col-md-6">
             <div class="panel panel-default panel-component">
                 <div class="panel-heading">
-                    <h3 class="panel-title"><?= basename($comp['url']) ?></h3>
+                    <h3 class="panel-title"><?= $name ?></h3>
                 </div>
 
                 <div class="panel-body">
@@ -47,42 +51,15 @@ reset($components);
 
                 <div class="panel-footer">
                     <i class="fa fa-github"></i>
-                    <a href="https://github.com/zendframework/<?= basename($comp['url']) ?>" target="_blank">Github</a>
+                    <a href="https://github.com/zendframework/<?= $name ?>" target="_blank">Github</a>
                     <span class="pull-right">
-                                    <i class="fa fa-book"></i>
-                                    <a href="<?= $comp['url'] ?>" target="_blank">Documentation</a>
-                                </span>
+                        <i class="fa fa-book"></i>
+                        <a href="https://docs.zendframework.com/<?= $name ?>" target="_blank">Documentation</a>
+                    </span>
                 </div>
             </div>
         </div>
-
-        <?php $comp = next($components) ?>
-
-        <?php if ($comp) : ?>
-            <div class="col-md-6">
-                <div class="panel panel-default panel-component">
-                    <div class="panel-heading">
-                        <h3 class="panel-title"><?= basename($comp['url']) ?></h3>
-                    </div>
-
-                    <div class="panel-body">
-                        <p><?= $comp['description'] ?></p>
-                    </div>
-
-                    <div class="panel-footer">
-                        <i class="fa fa-github"></i>
-                        <a href="https://github.com/zendframework/<?= basename($comp['url']) ?>" target="_blank">Github</a>
-                        <span class="pull-right">
-                                    <i class="fa fa-book"></i>
-                                    <a href="<?= $comp['url'] ?>" target="_blank">Documentation</a>
-                                </span>
-                    </div>
-                </div>
-            </div>
-        <?php endif ?>
-    </div>
-
-<?php endwhile; ?>
+<?php endforeach; ?>
 
 <?php $this->placeholder('sub-navigation')->set(
     $this->render('include::learn-menu', ['active' => '/learn'])

--- a/templates/include/modal-issue.phtml
+++ b/templates/include/modal-issue.phtml
@@ -16,8 +16,8 @@
 
                 <label for="gitrepo">Select GitHub repository:</label>
                 <select class="form-control" id="gitrepo">
-                <?php foreach ($repository as $repo) : ?>
-                    <option value="https://github.com/zendframework/<?= basename($repo['url']) ?>/issues/new"><?= $repo['name'] ?></option>
+                <?php foreach ($repository as $name => $repo) : ?>
+                    <option value="https://github.com/zendframework/<?= $name ?>/issues/new"><?= $name ?></option>
                 <?php endforeach; ?>
                 </select>
             </div>


### PR DESCRIPTION
Currently https://framework.zend.com/status does not contain all repositories from `zendframework` org (the same on [stats](https://framework.zend.com/stats), [documentation](https://framework.zend.com/learn), [issues](https://framework.zend.com/issues)). The current list is generated from https://github.com/zendframework/zf-mkdoc-theme/blob/gh-pages/scripts/zf-component-list.json which was created mainly to use in documentation.

I've created new script (`bin/repos.php <github-token>`) to generate config file with all repositories to get data from github api. It is using [`knplabs/github-api`](https://github.com/KnpLabs/php-github-api). I've added this as __development dependency*__ in composer, so for now it should be generated locally and committed to the repository. We can change it and add it to the build process. Scripts requires provide [`github-token`](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/#creating-a-token) - because there is hourly limit on github api request (without token is 60, with token is 5000*).
Generated component list is associative array:
```php
<?php
return [
    'zf-components' => [
        'component-name' => [
             'description' => '<github component description>',
             'docs' => <0|1>,
        ],
        ....
    ],
];
```

As you can see, `description` is fetched form github repository description, and probably it does not match description from [zf-component-list.json](https://github.com/zendframework/zf-mkdoc-theme/blob/gh-pages/scripts/zf-component-list.json). We can write another script to sychronize these descriptions.
`docs` has value `0` or `1` which means if there is documentation for the component. We check if `mkdocs.yml` file exists in the repository.

On [documentation](https://framework.zend.com/learn) page we display repositories only with documentation.

When we generate statistics we use only components published on packagist, so packages like `maintainers`, `zf3-web`, ... are not gonna be on the statistics list.

__*__ As I mentioned the script should be run locally, it's not a part of build process. This is because, not sure if you'd like to add these composer dependencies on production. Another concern is 5000 requests per hour (with github token). It seems to be a lot.
We have right now 149 repositories, so to generate the whole list of component we need to do around `~160` request to github api (1 request for each repo to check if `mkdocs.yml` exists, and listing all repositories). So even if we run build process multiple times on couple machines in the same hour it should be enough (shouldn't be?)

About dev dependencies... I just got an idea - if we slightly change build process:
1. install everything with dev dependencies 
2. build website (repos list, stats, ... everything what we have in `bin/build.php`)
3. run `composer install --no-dev` to remove dev dependencies needed to build the website

Then we can have it on build process. What do you think?