### PR TITLE
Added zend-db 2.9.0 release post

### DIFF
--- a/data/posts/2017-12-06-zend-db-2.9.0.md
+++ b/data/posts/2017-12-06-zend-db-2.9.0.md
@@ -1,0 +1,84 @@
+---
+layout: post
+title: A new release of zend-db
+date: 2017-12-06T11:02:00-05:00
+author: Enrico Zimuel
+url_author: https://www.zimuel.it
+permalink: /blog/2017-12-06-zend-db-2.9.0.html
+categories:
+- blog
+- zend-db
+- database
+
+---
+
+Today, we released [zend-db 2.9.0](https://github.com/zendframework/zend-db/releases/tag/release-2.9.0)!
+This release come after more than 1 year from the previous [2.8.2](https://github.com/zendframework/zend-db/releases/tag/release-2.8.2)
+and it contains 7 bug fixes, 6 new features, unit test and documentation
+improvements.
+
+**Zend-db** is an important component of many PHP projects and we know that its
+support is crucial for many people. We spent a lot of time to fix the reported
+issues and review all the PRs (more than 50).
+
+## Zend-db 2.9.0
+
+This release contains the following changes:
+
+### Added
+
+- [#216](https://github.com/zendframework/zend-db/pull/216) added AFTER support
+  in ALTER TABLE syntax for MySQL
+- [#223](https://github.com/zendframework/zend-db/pull/223) added support for
+  empty values set with IN predicate
+- [#271](https://github.com/zendframework/zend-db/pull/271) added support for
+  dash character on MySQL identifier
+- [#273](https://github.com/zendframework/zend-db/pull/273) added support for
+  implementing an error handler for db2_prepare
+- [#275](https://github.com/zendframework/zend-db/pull/275) added support for
+  LIMIT OFFSET for db2
+- [#280](https://github.com/zendframework/zend-db/pull/280) added version dsn
+  parameter for pdo_dblib
+
+### Fixed
+
+- [#205](https://github.com/zendframework/zend-db/pull/205) fixes the spaces in
+  ORDER BY syntax
+- [#224](https://github.com/zendframework/zend-db/pull/224) fixes how parameters
+  are bound to statements in the PDO adapter. PDO has a restriction on parameter
+  names of `[0-9a-zA_Z_]`; as such, the driver now hashes the parameter names
+  using `md5()` in order to ensure compatibility with other drivers.
+- [#229](https://github.com/zendframework/zend-db/pull/229) fixes the support
+  of SSL for mysqli
+- [#255](https://github.com/zendframework/zend-db/pull/255) fixes ResultSet with
+  array values
+- [#261](https://github.com/zendframework/zend-db/pull/261) fixes Exception in
+  Firebird driver doesn't support lastInsertId
+- [#276](https://github.com/zendframework/zend-db/pull/276) fixes the support
+  of PHP 7.2
+- [#287](https://github.com/zendframework/zend-db/pull/287) fixes the usage of
+  count() with PHP 7.2
+
+## Future of zend-db
+
+We are planning **zend-db 3.0.0** release for next year. This new major version
+will contains some cool new features like an extended [DDL support](https://github.com/zendframework/zend-db/pull/231)
+for different db vendors (right now is more MySQL oriented) the support of [SEQUENCE](https://docs.microsoft.com/en-us/sql/relational-databases/sequence-numbers/sequence-numbers)
+more bug fixes and some minor BC changes.
+
+If you want to contribute to zend-db, you are more than welcome! For more
+information you can read the [contribution guide](https://framework.zend.com/participate/contributor-guide)
+of the Zend Framework project.
+
+## Special thanks
+
+A special thanks to our contributors [Anaël Ollier](https://github.com/nanawel),
+[W.R. Guzmán](https://github.com/WellingGuzman), [Rob Allen](https://github.com/akrabat),
+[Václav Vaník](https://github.com/vaclavvanik), [Sasha Alex Romanenko](https://github.com/alextech),
+[Zdenek Machek](https://github.com/machek), [Bart McLeod](https://github.com/bartmcleod),
+[Cyrille Grandval](https://github.com/cgrandval), [Remi Collet](https://github.com/remicollet),
+[Michał Bundyra](https://github.com/webimpress) and our review team for this new
+release of zend-db.
+
+We don't know if this will be the last post for this year, **Merry Christmas and
+Happy new Year from the Zend Framework Team!**

--- a/data/posts/2017-12-06-zend-db-2.9.0.md
+++ b/data/posts/2017-12-06-zend-db-2.9.0.md
@@ -59,12 +59,15 @@ This release contains the following changes:
 - [#287](https://github.com/zendframework/zend-db/pull/287) fixes the usage of
   count() with PHP 7.2
 
+We also dropped the support of PHP 5.5 (EOL last year), now we are supporting
+PHP 5.6+.
+
 ## Future of zend-db
 
 We are planning **zend-db 3.0.0** release for next year. This new major version
 will contains some cool new features like an extended [DDL support](https://github.com/zendframework/zend-db/pull/231)
 for different db vendors (right now is more MySQL oriented) the support of [SEQUENCE](https://docs.microsoft.com/en-us/sql/relational-databases/sequence-numbers/sequence-numbers)
-more bug fixes and some minor BC changes.
+more bug fixes and some BC changes, like the support of PHP 7.1+.
 
 If you want to contribute to zend-db, you are more than welcome! For more
 information you can read the [contribution guide](https://framework.zend.com/participate/contributor-guide)

--- a/data/posts/2017-12-06-zend-db-2.9.0.md
+++ b/data/posts/2017-12-06-zend-db-2.9.0.md
@@ -83,5 +83,5 @@ A special thanks to our contributors [Anaël Ollier](https://github.com/nanawel)
 [Michał Bundyra](https://github.com/webimpress) and our review team for this new
 release of zend-db.
 
-We don't know if this will be the last post for this year, **Merry Christmas and
-Happy new Year from the Zend Framework Team!**
+We don't know if this will be the last post for this year, anyway
+**Merry Christmas and Happy new Year from the Zend Framework Team!**


### PR DESCRIPTION
This PR contains a new blog post about the release 2.9.0 of zend-db.