### PR TITLE
Hotfix - typo - Expressive 3.0 dev

### DIFF
--- a/data/posts/2017-12-14-expressive-3-dev.md
+++ b/data/posts/2017-12-14-expressive-3-dev.md
@@ -74,7 +74,7 @@ Our approach in updating the various packages was as follows:
   `"dev-release-3.0.0": "3.0.x-dev".
 - On the release branches, we updated dependencies as follows:
   - PHP dependencies became simply `^7.1` (per [our decision posted in
-    June](https://framework.zend.com/blog/2017-06-06-zf-php-7-1.html).
+    June](https://framework.zend.com/blog/2017-06-06-zf-php-7-1.html)).
   - References to `http-interop/http-middleware` packages were changed to
     `"http-interop/http-server-middleware": "^1.0.1"`.
   - References to packages that have corresponding release branches were updated

--- a/data/posts/2017-12-14-expressive-3-dev.md
+++ b/data/posts/2017-12-14-expressive-3-dev.md
@@ -108,7 +108,7 @@ This is all very nice and technical, but how can YOU test out the new versions?
 Install the development version of the Expressive skeleton!
 
 ```bash
-$ composer create-project "zendframework/zend-expressive-skeleton:3.0.0-dev" expressive-3.0-dev
+$ composer create-project "zendframework/zend-expressive-skeleton:3.0.x-dev" expressive-3.0-dev
 ```
 
 This will create the skeleton project, with your selected functionality, in a


### PR DESCRIPTION
- Added missing closing bracket
- Fixed Expressive target on create project: should be `3.0.x-dev` instead of `3.0.0-dev`, when I tried:
```console
$ composer create-project "zendframework/zend-expressive-skeleton:3.0.0-dev" expressive-3.0-dev
```
I've got:
```
 [InvalidArgumentException]                                                             
  Could not find package zendframework/zend-expressive-skeleton with version 3.0.0-dev.  
```

/cc @ezimuel @weierophinney 