### PR TITLE
Changed header "migrating to rc1"

### DIFF
--- a/data/posts/2018-02-27-expressive-3-rc1.md
+++ b/data/posts/2018-02-27-expressive-3-rc1.md
@@ -113,7 +113,7 @@ You can also create middleware to add to your application pipeline, or within
 route-specific pipelines. From here, you have the basic building blocks and
 application structure to get started!
 
-## Migrating from alpha3 and rc1
+## Migrating from alpha3 to rc1
 
 While a ton has changed between the 3.0.0alpha3 release and today, most
 applications built on alpha3 should be able to continue working as they were


### PR DESCRIPTION
The header "Migrating from alpha3 and rc1" is wrong and must be changed to the following:
    "Migrating from alpha3 to rc1"

It makes more sense and then the link in the list is working again